### PR TITLE
Accept ssh protocol

### DIFF
--- a/furo2/furo2.py
+++ b/furo2/furo2.py
@@ -61,7 +61,7 @@ def _init_project():
     project_file = Path(root_dir) / 'project.yml'
 
     repository = git_output(['config', 'remote.origin.url']).strip()
-    repo_path = re.sub(r'^https?://|^ssh://|\.git$', '', repository, 2)
+    repo_path = re.sub(r'^https?://|^ssh://|\.git$', '', repository)
     repo_path = re.sub(
         r'^[a-zA-Z0-9_]+@([a-zA-Z0-9._-]+):(.*)$', r'\1/\2', repo_path)
 

--- a/furo2/furo2.py
+++ b/furo2/furo2.py
@@ -61,7 +61,7 @@ def _init_project():
     project_file = Path(root_dir) / 'project.yml'
 
     repository = git_output(['config', 'remote.origin.url']).strip()
-    repo_path = re.sub(r'^https?://|\.git$', '', repository)
+    repo_path = re.sub(r'^https?://|^ssh://|\.git$', '', repository, 2)
     repo_path = re.sub(
         r'^[a-zA-Z0-9_]+@([a-zA-Z0-9._-]+):(.*)$', r'\1/\2', repo_path)
 


### PR DESCRIPTION
remote.origin.url allows ssh protocol.

------------------------

```python
import re

s1 = re.sub(r'^https?://|^ssh://|\.git$', '', 'ssh://git@github.com/t-mrt/furoshiki2.git');
print(s1)
s2 = re.sub(r'^https?://|^ssh://|\.git$', '', 'https://git@github.com/t-mrt/furoshiki2.git');
print(s2)
s3 = re.sub(r'^https?://|^ssh://|\.git$', '', 'http://git@github.com/t-mrt/furoshiki2.git');
print(s3)
```

```
% python a.py
git@github.com/t-mrt/furoshiki2
git@github.com/t-mrt/furoshiki2
git@github.com/t-mrt/furoshiki2
```